### PR TITLE
Fix SQL error in mysql strict mode and TYPO3 8.7

### DIFF
--- a/Configuration/TCA/tx_maps2_domain_model_poicollection.php
+++ b/Configuration/TCA/tx_maps2_domain_model_poicollection.php
@@ -280,6 +280,7 @@ return array(
                 'cols' => 40,
                 'rows' => 15,
                 'eval' => 'trim',
+                'default => '',
             ),
             'defaultExtras' => 'richtext[]',
         ),


### PR DESCRIPTION
Fixeds  SQL error: 'Field 'info_window_content' doesn't have a default value' (tx_maps2_domain_model_poicollection:NEW595b818f2d21a131234066)

When entering new marker and changing the "Type"