### PR TITLE
[TASK] Fix condition in Maps2Registry documentation

### DIFF
--- a/Documentation/DeveloperManual/Maps2Registry/Index.rst
+++ b/Documentation/DeveloperManual/Maps2Registry/Index.rst
@@ -177,7 +177,7 @@ Example for tt_address
    }
 
    call_user_func(function() {
-       if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('tt_address')) {
+       if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('maps2')) {
            \JWeiland\Maps2\Tca\Maps2Registry::getInstance()->add(
                'tt_address',
                'tt_address',


### PR DESCRIPTION
The tt_address example in the Maps2Registry Documentation should check if maps2 is loaded not tt_address, because the maps2 api is called.