### PR TITLE
[BUGFIX] Handle unavailable `is_in` config

### DIFF
--- a/Classes/Form/Element/ReadOnlyInputTextElement.php
+++ b/Classes/Form/Element/ReadOnlyInputTextElement.php
@@ -124,7 +124,7 @@ class ReadOnlyInputTextElement extends AbstractFormElement
             'data-formengine-input-params' => json_encode([
                 'field' => $parameterArray['itemFormElName'],
                 'evalList' => implode(',', $evalList),
-                'is_in' => trim($config['is_in'])
+                'is_in' => trim($config['is_in'] ?? '')
             ]),
             'data-formengine-input-name' => $parameterArray['itemFormElName'],
         ];


### PR DESCRIPTION
`$config['is_in']` may be undefined which causes issues when being
trimmed. This change adds a null coalesce to an empty string if this is
the case to avoid PHP type errors.

Fixes: #192