### PR TITLE
Always provide a configuration for the map in the backend form, solves #223

### DIFF
--- a/Classes/Form/Element/GoogleMapsElement.php
+++ b/Classes/Form/Element/GoogleMapsElement.php
@@ -185,7 +185,10 @@ class GoogleMapsElement extends AbstractFormElement
      */
     protected function getConfiguration(array $currentRecord)
     {
-        $config = [];
+        $config = [
+            'latitude' => $this->extConf->getDefaultLatitude(),
+            'longitude' => $this->extConf->getDefaultLongitude()
+        ];
 
         // get poi collection model
         $uid = (int)$currentRecord['uid'];
@@ -214,15 +217,16 @@ class GoogleMapsElement extends AbstractFormElement
                 default:
                     break;
             }
-
-            $config['address'] =  $currentRecord['address'];
-            $config['collectionType'] = is_array($currentRecord['collection_type']) ? $currentRecord['collection_type'][0] : $currentRecord['collection_type'];
-            $config['uid'] =  $uid;
-
-            $hashArray['uid'] = $uid;
-            $hashArray['collectionType'] = $currentRecord['collection_type'];
-            $config['hash'] = $this->hashService->generateHmac(serialize($hashArray));
         }
+
+        $config['address'] =  $currentRecord['address'];
+        $config['collectionType'] = is_array($currentRecord['collection_type']) ? $currentRecord['collection_type'][0] : $currentRecord['collection_type'];
+        $config['uid'] =  $uid === 0 ? $currentRecord['uid'] : $uid;
+
+        $hashArray['uid'] = $uid === 0 ? $currentRecord['uid'] : $uid;
+        $hashArray['collectionType'] = $currentRecord['collection_type'];
+        $config['hash'] = $this->hashService->generateHmac(serialize($hashArray));
+
         return $config;
     }
 

--- a/Classes/Form/Element/OpenStreetMapElement.php
+++ b/Classes/Form/Element/OpenStreetMapElement.php
@@ -158,7 +158,10 @@ class OpenStreetMapElement extends AbstractFormElement
      */
     protected function getConfiguration(array $currentRecord): array
     {
-        $config = [];
+        $config = [
+            'latitude' => $this->extConf->getDefaultLatitude(),
+            'longitude' => $this->extConf->getDefaultLongitude()
+        ];
 
         // get poi collection model
         $uid = (int)$currentRecord['uid'];
@@ -187,15 +190,16 @@ class OpenStreetMapElement extends AbstractFormElement
                 default:
                     break;
             }
-
-            $config['address'] =  $currentRecord['address'];
-            $config['collectionType'] = is_array($currentRecord['collection_type']) ? $currentRecord['collection_type'][0] : $currentRecord['collection_type'];
-            $config['uid'] =  $uid;
-
-            $hashArray['uid'] = $uid;
-            $hashArray['collectionType'] = $currentRecord['collection_type'];
-            $config['hash'] = $this->hashService->generateHmac(serialize($hashArray));
         }
+
+        $config['address'] =  $currentRecord['address'];
+        $config['collectionType'] = is_array($currentRecord['collection_type']) ? $currentRecord['collection_type'][0] : $currentRecord['collection_type'];
+        $config['uid'] =  $uid === 0 ? $currentRecord['uid'] : $uid;
+
+        $hashArray['uid'] = $uid === 0 ? $currentRecord['uid'] : $uid;
+        $hashArray['collectionType'] = $currentRecord['collection_type'];
+        $config['hash'] = $this->hashService->generateHmac(serialize($hashArray));
+
         return $config;
     }
 


### PR DESCRIPTION
All not PoiCollection related parameter to setup the field 'configuration_map' in the backend view were moved outside of the related condition. 

Additionally:

- defaults were provided for latitude and longitude
- uid is set to 'NEW...' if it was 0 before, it's neccessary to hit the form fields correctly