### PR TITLE
[DOCS] Fix table in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ OpenStreetMap. The map can be additionally enriched with markers, routes,
 area and radius overlays and these overlays can be grouped into categories
 for easy and recurring assignment.
 
+| Type         | URL                                                 |
+|--------------|-----------------------------------------------------|
 | Repository:  | https://github.com/jweiland-net/maps2               |
 | Read online: | https://docs.typo3.org/p/jweiland/maps2/main/en-us/ |
 | TER:         | https://extensions.typo3.org/extension/maps2        |


### PR DESCRIPTION
The markdown parser of GitHub requires a table header row.