### PR TITLE
Use special=language for TCA column sys_language_uid

### DIFF
--- a/Configuration/TCA/tx_maps2_domain_model_poicollection.php
+++ b/Configuration/TCA/tx_maps2_domain_model_poicollection.php
@@ -102,18 +102,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'select',
-                'renderType' => 'selectSingle',
-                'special' => 'languages',
-                'items' => [
-                    [
-                        'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.allLanguages',
-                        -1,
-                        'flags-multiple'
-                    ],
-                ],
-                'default' => 0,
-            ]
+                'type' => 'language',
+            ],
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',


### PR DESCRIPTION
which is available since TYPO3 11.2