### PR TITLE
Replace deprecated TYPO3_MODE const with TYPO3

### DIFF
--- a/Configuration/TCA/Overrides/sys_category.php
+++ b/Configuration/TCA/Overrides/sys_category.php
@@ -1,6 +1,6 @@
 <?php
 
-if (!defined('TYPO3_MODE')) {
+if (!defined('TYPO3')) {
     die('Access denied.');
 }
 

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,6 +1,6 @@
 <?php
 
-if (!defined('TYPO3_MODE')) {
+if (!defined('TYPO3')) {
     die('Access denied.');
 }
 

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,6 +1,6 @@
 <?php
 
-if (!defined('TYPO3_MODE')) {
+if (!defined('TYPO3')) {
     die('Access denied.');
 }
 

--- a/Configuration/TCA/Overrides/tx_maps2_domain_model_poicollection.php
+++ b/Configuration/TCA/Overrides/tx_maps2_domain_model_poicollection.php
@@ -1,6 +1,6 @@
 <?php
 
-if (!defined('TYPO3_MODE')) {
+if (!defined('TYPO3')) {
     die('Access denied.');
 }
 

--- a/Documentation/DeveloperManual/Maps2Registry/Index.rst
+++ b/Documentation/DeveloperManual/Maps2Registry/Index.rst
@@ -175,7 +175,7 @@ Example for tt_address
 ..  code-block:: php
 
     <?php
-    if (!defined('TYPO3_MODE')) {
+    if (!defined('TYPO3')) {
         die('Access denied.');
     }
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,7 +1,7 @@
 <?php
 
-if (!defined('TYPO3_MODE')) {
-    die('Access denied.');
+if (!defined('TYPO3')) {
+    die('Access denied');
 }
 
 call_user_func(static function (): void {

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('TYPO3_MODE')) {
+if (!defined('TYPO3')) {
     die('Access denied.');
 }
 


### PR DESCRIPTION
The TYPO3_MODE constant was deprecated in v11 and removed in v12 
see: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.0/Deprecation-92947-DeprecateTYPO3_MODEAndTYPO3_REQUESTTYPEConstants.html#

This change is required to make extension compatible with TYPO3 v12