### PR TITLE
[BUGFIX] Remove superfluous column from TCA

### DIFF
--- a/Configuration/TCA/tx_maps2_domain_model_poicollection.php
+++ b/Configuration/TCA/tx_maps2_domain_model_poicollection.php
@@ -135,14 +135,6 @@ return [
                 'default' => '',
             ],
         ],
-        't3ver_label' => [
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.versionLabel',
-            'config' => [
-                'type' => 'input',
-                'size' => 30,
-                'max' => 255,
-            ],
-        ],
         'hidden' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.visible',


### PR DESCRIPTION
The superfluous definition for column `t3ver_label` with no related database column breaks e.g. an export, if `all columns` has been selected, because TYPO3 then adds all columns from TCA to the SELECT statement, but the column `t3ver_label` is no longer available in the database table tx_maps2_domain_model_poicollection.

This bugfix removes the superfluous column from TCA definition.

Resolves: #301