### PR TITLE
[BUGFIX] Fix impicit nullable parameter

### DIFF
--- a/Classes/Controller/PoiCollectionController.php
+++ b/Classes/Controller/PoiCollectionController.php
@@ -83,7 +83,7 @@ class PoiCollectionController extends ActionController
         return $this->htmlResponse();
     }
 
-    public function searchAction(Search $search = null): ResponseInterface
+    public function searchAction(?Search $search = null): ResponseInterface
     {
         $search ??= GeneralUtility::makeInstance(Search::class);
 


### PR DESCRIPTION
Implicitly nullable parameters are deprecated since PHP 8.4 and trigger an E_DEPRECATED error.

Parameter `$search` in PoiCollectionController->searchAction is now explicitly marked as nullable.